### PR TITLE
Add subnet outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 A Terraform Module that helps you create projects for Google Cloud Platform.
 
+## Features
+
+By default, the module creates the following regional resources:
+
+- a GCP project with a randomized but memorable project ID and name
+- a new project service account, replacing the default account
+- a Terraform state bucket in the host project for the project's state
+- a KMS keyring and encryption key for asymmetric encryption/decryption
+- a GCS bucket for logging access to the project storage bucket, with encryption enabled using the project's KMS key
+- a GCS bucket for project-wide storage of sensitive objects, with encryption enabled using the project's KMS key
+- a VPC network configured as a service network on the Shared VPC host network
+- a default firewall rule blocking SSH from anywhere but inside of GCP Cloud Console
+
+_Only_ the GCP project itself and the service account are required. Everything else is optional and configurable.
+
 ## Goals
 
 #### Include batteries, _and_ be minimal
@@ -29,23 +44,6 @@ Use [HCL](https://github.com/hashicorp/hcl) and Terraform as idiomatically as po
 - only creating dependencies on external scripts or tools if absolutely necessary
 - not making assumptions about environments or relying on idiosyncratic environment configuration
 - etc.
-
-## Features
-
-By default, the module creates the following regional resources:
-
-- a GCP project with a randomized but memorable project ID and name
-- a new project service account, replacing the default account
-- a Terraform state bucket in the host project for the project's state
-- a KMS keyring and encryption key for asymmetric encryption/decryption
-- a GCS bucket for logging access to the project storage bucket, with encryption enabled using the project's KMS key
-- a GCS bucket for project-wide storage of sensitive objects, with encryption enabled using the project's KMS key
-- a VPC network configured as a service network on the Shared VPC host network
-- a default firewall rule blocking SSH from anywhere but inside of GCP Cloud Console
-
-_Only_ the GCP project itself and the service account are required. Everything else is optional and configurable.
-
-Module main.
 
 ## Inputs
 
@@ -102,7 +100,8 @@ Check [_docs/graph.png](https://github.com/minnowpod/terraform-google-project/bl
 ```hcl
 // Create a default project
 module "my-project" {
-  source = "github.com/minnowpod/terraform-google-project?ref=v0.1.0"
+  source  = "minnowpod/terraform-google-project"
+  version = "~> 0.2.0"
 
   // these can also be passed from the environment with TF_VAR_billing_account, for example
   billing_account = "bar"
@@ -125,7 +124,8 @@ module "my-project" {
 
 // Add an additional VPC network
 module "another-vpc" {
-  source = "github.com/minnowpod/terraform-google-project//modules/vpc?ref=v0.1.0"
+  source  = "minnowpod/terraform-google-project//modules/vpc"
+  version = "~> 0.2.0"
 
   // but skip the SSH firewall rule on this one
   create_ssh_fw_rule = "false"

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -1,6 +1,6 @@
-# GCS Bucket Module
+# Shared VPC Module
 
-More information about [Cloud Storage](https://cloud.google.com/storage/).
+More information about [Shared VPC](https://cloud.google.com/vpc/docs/shared-vpc).
 
 ## Inputs
 
@@ -9,13 +9,14 @@ More information about [Cloud Storage](https://cloud.google.com/storage/).
 | host\_project | The project ID of the GCP project used by Terraform to create this project. | string | - |
 | project\_id | The project ID. | string | - |
 | service\_account\_email | The email address of the project SA to grant access to networking resources. | string | - |
+| services | Only used to ensure that API services are enabled before creating VPC resources. | string | - |
 | auto\_create\_subnets | Whether or not to automatically create subnets on this VPC. | string | `false` |
 | create\_ssh\_fw\_rule | If true, this will create a firewall rule preventing SSH access from anywhere but within Cloud Console. | string | `true` |
 | create\_vpc\_network | Whether or not to create a VPC network for the project. If `'true'`, this will try to configure this project as a service project on the host project's VPC network's shared subnet. | string | `true` |
 | flow\_logs | Whether to enable flow logging for the Shared VPC subnetwork. | string | `true` |
 | fw\_rule\_name | A name for the SSH firewall rule. One will be generated based on your `project_id` if you leave this blank. | string | `` |
 | host\_dns\_zone | The VPC host network's managed DNS zone. | string | `` |
-| network\_name | A unique name for the network, required by GCE. | string | `` |
+| network\_name | A unique name for the VPC network, required by GCE. | string | `` |
 | private\_access | Whether to allow private access to Google APIs without an external IP address. | string | `true` |
 | region | The preferred region to use for resources that require a region to be defined. | string | `us-central1` |
 | routing\_mode | Sets the network-wide routing mode for Cloud Routers to use. Accepted values are 'GLOBAL' or 'REGIONAL'. | string | `REGIONAL` |
@@ -25,11 +26,15 @@ More information about [Cloud Storage](https://cloud.google.com/storage/).
 
 | Name | Description |
 |------|-------------|
-| auto\_create\_subnetworks | - |
-| gateway\_ipv4 | - |
-| name | - |
-| routing\_mode | - |
-| self\_link | - |
+| auto\_create\_subnetworks | Whether or not subnets will be (in plan) or were (in apply) automatically created on this VPC. |
+| flow\_logs | Whether you have enabled flow logging for the Shared VPC subnetwork. |
+| gateway\_ipv4 | The IPv4 address of the gateway. |
+| ips | The VPC subnets IP range in CIDR format. |
+| name | The unique name for the VPC network, required by GCE. |
+| private\_access | Whether you have allowed private access to Google APIs without an external IP address. |
+| routing\_mode | The network-wide routing mode for Cloud Routers.. |
+| self\_link | The URI of the created resource. |
+| subnets | The VPC subnets that will be (in plan) or were (in apply) created. |
 
 
 

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,19 +1,44 @@
 output "name" {
-  value = "${google_compute_network.service_network.*.name}"
+  value       = "${google_compute_network.service_network.*.name}"
+  description = "The unique name for the VPC network, required by GCE."
 }
 
 output "auto_create_subnetworks" {
-  value = "${google_compute_network.service_network.*.auto_create_subnetworks}"
+  value       = "${google_compute_network.service_network.*.auto_create_subnetworks}"
+  description = "Whether or not subnets will be (in plan) or were (in apply) automatically created on this VPC."
 }
 
 output "routing_mode" {
-  value = "${google_compute_network.service_network.*.routing_mode}"
+  value       = "${google_compute_network.service_network.*.routing_mode}"
+  description = "The network-wide routing mode for Cloud Routers.."
 }
 
 output "gateway_ipv4" {
-  value = "${google_compute_network.service_network.*.gateway_ipv4}"
+  value       = "${google_compute_network.service_network.*.gateway_ipv4}"
+  description = "The IPv4 address of the gateway."
 }
 
 output "self_link" {
-  value = "${google_compute_network.service_network.*.self_link}"
+  value       = "${google_compute_network.service_network.*.self_link}"
+  description = "The URI of the created resource."
+}
+
+output "subnets" {
+  value       = "${google_compute_subnetwork.service_subnet.*.name}"
+  description = "The VPC subnets that will be (in plan) or were (in apply) created."
+}
+
+output "ips" {
+  value       = "${google_compute_subnetwork.service_subnet.*.ip_cidr_range}"
+  description = "The VPC subnets IP range in CIDR format."
+}
+
+output "private_access" {
+  value       = "${google_compute_subnetwork.service_subnet.*.private_ip_google_access}"
+  description = "Whether you have allowed private access to Google APIs without an external IP address."
+}
+
+output "flow_logs" {
+  value       = "${google_compute_subnetwork.service_subnet.*.enable_flow_logs}"
+  description = "Whether you have enabled flow logging for the Shared VPC subnetwork."
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -35,7 +35,7 @@ variable "create_vpc_network" {
 }
 
 variable "network_name" {
-  description = " A unique name for the network, required by GCE."
+  description = "A unique name for the VPC network, required by GCE."
   default     = ""
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -74,9 +74,13 @@ output "vpc" {
   description = "Project VPC network details."
 
   value = {
-    network_name         = "${module.vpc.name}"
-    network_routing_mode = "${module.vpc.routing_mode}"
-    network_gateway      = "${module.vpc.gateway_ipv4}"
-    network_self_link    = "${module.vpc.self_link}"
+    network_name          = "${module.vpc.name}"
+    network_routing_mode  = "${module.vpc.routing_mode}"
+    network_gateway       = "${module.vpc.gateway_ipv4}"
+    network_self_link     = "${module.vpc.self_link}"
+    subnet_names          = "${module.vpc.subnets}"
+    subnet_ips            = "${module.vpc.ips}"
+    subnet_private_access = "${module.vpc.private_access}"
+    subnet_flow_logs      = "${module.vpc.flow_logs}"
   }
 }


### PR DESCRIPTION
Fixes #4.

Output:

```hcl
vpc = {
  network_gateway = []
  network_name = [exotic-bluejay-5c0ffeb1-net]
  network_routing_mode = [REGIONAL]
  network_self_link = [https://www.googleapis.com/compute/v1/projects/exotic-bluejay-5c0ffeb1/global/networks/exotic-bluejay-5c0ffeb1-net]
  subnet_flow_logs = [true]
  subnet_ips = [10.128.0.0/20]
  subnet_names = [exotic-bluejay-5c0ffeb1-subnet]
  subnet_private_access = [true]
}
```

Signed-off-by: Carlo DiCelico <carlo@minnow.me>